### PR TITLE
Conditional TypesDB definition

### DIFF
--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -4,7 +4,9 @@
 # General options
 Interval     {{ collectd_interval }}
 ReadThreads  {{ collectd_readthreads }}
+{% if collectd_types is defined and collectd_types | length > 0 %}
 TypesDB "{{collectd_types_path}}/types.db"
+{% endif %}
 {% if collectd_hostname %}Hostname {{ collectd_hostname }}
 {% endif %}
 FQDNLookup {{ 'true' if collectd_fdqnlookup else 'false' }}

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -4,9 +4,8 @@
 # General options
 Interval     {{ collectd_interval }}
 ReadThreads  {{ collectd_readthreads }}
-{% if collectd_types is defined and collectd_types | length > 0 %}
+TypesDB /usr/share/collectd/types.db
 TypesDB "{{collectd_types_path}}/types.db"
-{% endif %}
 {% if collectd_hostname %}Hostname {{ collectd_hostname }}
 {% endif %}
 FQDNLookup {{ 'true' if collectd_fdqnlookup else 'false' }}

--- a/templates/collectd.conf.j2
+++ b/templates/collectd.conf.j2
@@ -4,7 +4,7 @@
 # General options
 Interval     {{ collectd_interval }}
 ReadThreads  {{ collectd_readthreads }}
-TypesDB /usr/share/collectd/types.db
+TypesDB "/usr/share/collectd/types.db"
 TypesDB "{{collectd_types_path}}/types.db"
 {% if collectd_hostname %}Hostname {{ collectd_hostname }}
 {% endif %}


### PR DESCRIPTION
Define TypesDB directive in collectd.conf only if we have TypeDB defined.
This is necessary for instance to avoid log messages like:

  plugin_dispatch_values: No data sets registered. Could the types database be read? Check your `TypesDB' setting!

And also I detected that with this directive pointing to an empty types.db file causes 'network' plugin stop working.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/replaygaming/collectd-ansible/1)

<!-- Reviewable:end -->
